### PR TITLE
Change sensor unique id generation and update `direction` value type

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,15 @@ sensor:
         stop_id: 900110001 # actual Stop ID for the API
       - name: "Stargarder Str." # you can add more that one stop to track
         stop_id: 900000110501
-        # direction: "S Hackescher Markt" # optional: filter out lines by direction
-        # walking_time: 5 # optional (minutes): hide transport closer than N minutes
+        
+        # Optional parameter that filter out sensor stop direction by setting stop_id 
+        # of any stop on a desired route.
+        # stop_id can be found via the similar request:
+        # [curl https://v5.vbb.transport.rest/locations\?query\=S+Hackescher+Markt | jq]
+        # direction: 900000100002
+        
+        # Optional parameter with value in minutes that hide transport closer than N minutes
+        # walking_time: 5
 ```
 
 **4.** Restart Home Assistant core again and you should now see two new entities (however, it may take some time for them to fetch new data). If you don't see anything new — check the logs (Settings -> System -> Logs). Some error should pop up there.
@@ -70,6 +77,9 @@ When sensor component is installed and working you can add the new fancy widget 
     - sensor.stop_id_900110001 # use your entity IDs here
     - sensor.stargarder_str # they might be different from mine
 ```
+
+## 🚨 Update
+This update brings new sensor id generation. It will result in deactivation of sensors with the old ids. All of those inactive sensors can be manually deleted either from the lovelace card directly and refreshing the dashboard or from the entities list in `Settings`.
 
 ## 🎨 Styling
 

--- a/custom_components/berlin_transport/sensor.py
+++ b/custom_components/berlin_transport/sensor.py
@@ -51,7 +51,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
             {
                 vol.Required(CONF_DEPARTURES_NAME): str,
                 vol.Required(CONF_DEPARTURES_STOP_ID): int,
-                vol.Optional(CONF_DEPARTURES_DIRECTION): str,
+                vol.Optional(CONF_DEPARTURES_DIRECTION): int,
                 vol.Optional(CONF_DEPARTURES_WALKING_TIME, default=1): int,
                 **TRANSPORT_TYPES_SCHEMA,
             }
@@ -80,7 +80,7 @@ class TransportSensor(SensorEntity):
         self.config: dict = config
         self.stop_id: int = config[CONF_DEPARTURES_STOP_ID]
         self.sensor_name: str | None = config.get(CONF_DEPARTURES_NAME)
-        self.direction: str | None = config.get(CONF_DEPARTURES_DIRECTION)
+        self.direction: int | None = config.get(CONF_DEPARTURES_DIRECTION)
         self.walking_time: int = config.get(CONF_DEPARTURES_WALKING_TIME) or 1
         # we add +1 minute anyway to delete the "just gone" transport
 
@@ -97,7 +97,7 @@ class TransportSensor(SensorEntity):
 
     @property
     def unique_id(self) -> str:
-        return f"stop_{self.stop_id}_departures"
+        return f"stop_{self.stop_id}_{self.sensor_name}_departures"
 
     @property
     def state(self) -> str:


### PR DESCRIPTION
This PR covers two changes:

1. With the current approach to sensor `unique_id` generation is not possible to have sensors that covers both directions for the same stop. Example in my case was a bus stop with the same `stop_id` that in one direction leads to the S-Bahn and in another to the U-Bahn so I need so see both schedules. The solution was to add sensor name to the sensor id value.

2. When I'm adding direction value as a stop name, like this: 

```shell
curl https://v5.vbb.transport.rest/stops/900000075154/departures\?when\=2022-12-11T19%3A00%3A03.200734\&direction\=U+Hermannplatz\&results\=10bus\=True | jq 
```

 I'm getting an error:

  ```
   {
    "error": true,
    "msg": "direction must be an IBNR"
}
 ```
 
  So I've changed data type of a `direction` to `int` which is the direction `stop_id` that can be collected from the API call mentioned [here](https://github.com/vas3k/home-assistant-berlin-transport#how-do-i-find-my-stop_id).
