### PR TITLE
Add logic to handle cancelled departures

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ When sensor component is installed and working you can add the new fancy widget 
   entities:
     - sensor.stop_id_900110001 # use your entity IDs here
     - sensor.stargarder_str # they might be different from mine
+  show_cancelled: true # show or hide the cancelled departures. When not defined or true, the cancelled departures will be shown as struk-through.
 ```
 
 ## 🚨 Update

--- a/custom_components/berlin_transport/departure.py
+++ b/custom_components/berlin_transport/departure.py
@@ -19,6 +19,7 @@ class Departure:
     bg_color: str | None = None
     fallback_color: str | None = None
     location: tuple[float, float] | None = None
+    cancelled: bool = False
 
     @classmethod
     def from_dict(cls, source):
@@ -39,6 +40,7 @@ class Departure:
                 source.get("currentTripPosition", {}).get("latitude") or 0.0,
                 source.get("currentTripPosition", {}).get("longitude") or 0.0,
             ],
+            cancelled=source.get("cancelled", False),
         )
 
     def to_dict(self):
@@ -48,4 +50,5 @@ class Departure:
             "time": self.time,
             "direction": self.direction,
             "color": self.fallback_color or self.bg_color,
+            "cancelled": self.cancelled,
         }

--- a/www/berlin-transport-timetable-card.js
+++ b/www/berlin-transport-timetable-card.js
@@ -13,8 +13,9 @@ class BerlinTransportTimetableCard extends HTMLElement {
 
         const config = this.config;
         const maxEntries = config.max_entries || 10;
-        const showStopName = config.show_stop_name || true;
+        const showStopName = config.show_stop_name || (config.show_stop_name === undefined);
         const entityIds = config.entity ? [config.entity] : config.entities || [];
+        const show_cancelled = config.show_cancelled || (config.show_cancelled === undefined);
 
         let content = "";
 
@@ -29,7 +30,8 @@ class BerlinTransportTimetableCard extends HTMLElement {
             }
 
             const timetable = entity.attributes.departures.slice(0, maxEntries).map((departure) => 
-                `<div class="departure">
+                departure.cancelled && !show_cancelled ? `` :
+                `<div class="${departure.cancelled ? 'departure-cancelled' : 'departure'}">
                     <div class="line">
                         <div class="line-icon" style="background-color: ${departure.color}">${departure.line_name}</div>
                     </div>
@@ -75,6 +77,16 @@ class BerlinTransportTimetableCard extends HTMLElement {
                 padding-bottom: 20px;
             }
             .departure {
+                padding-top: 10px;
+                display: flex;
+                flex-direction: row;
+                flex-wrap: nowrap;
+                align-items: flex-start;
+                gap: 20px;
+            }
+            .departure-cancelled {
+                text-decoration: line-through;
+                filter: grayscale(50%);
                 padding-top: 10px;
                 display: flex;
                 flex-direction: row;


### PR DESCRIPTION
Hi,

I have added the logic to handle cancelled departures.

A departure can have a property `cancelled` set to `true`. Unfortunately, this property is not always present, but it is mentioned in the example response here https://github.com/public-transport/hafas-client/blob/5/docs/departures.md, and I have seen it a couple of times myself as well.

The changes introduce a cancelled property to the `Departure` class and updates the UI such that the cancelled departures appear struck-through by default and can be configured not to be shown entirely.