### PR TITLE
Update README.md to reflect possibility to hide transport options

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ sensor:
         stop_id: 900110001 # actual Stop ID for the API
         # direction: 900000100002 # Optional stop_id to limit departures for a specific direction (same URL as to find the stop_id)
         # walking_time: 5 # Optional parameter with value in minutes that hides transport closer than N minutes
+        # suburban: false # Optionally hide transport options
         # show_official_line_colors: true # Optionally enable official VBB line colors. By default predefined colors will be used.
       - name: "Stargarder Str." # currently you have to add more than one stop to track
         stop_id: 900000110501


### PR DESCRIPTION
Just a tiny change in the README to show that you can easily hide transport options you aren't interested in, as mentioned in #18 