### PR TITLE
feat: Support multiple directions

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,14 +57,14 @@ sensor:
     departures:
       - name: "S+U Schönhauser Allee" # free-form name, only for display purposes
         stop_id: 900110001 # actual Stop ID for the API
-        # direction: 900000100002 # Optional stop_id to limit departures for a specific direction (same URL as to find the stop_id)
+        # direction: 900110002,900007102 # Optional stop_id to limit departures for a specific direction (same URL as to find the stop_id), multiple Values can be specified using a comma separated list
         # walking_time: 5 # Optional parameter with value in minutes that hides transport closer than N minutes
         # suburban: false # Optionally hide transport options
         # show_official_line_colors: true # Optionally enable official VBB line colors. By default predefined colors will be used.
         # duration: 30 # Optional (default 10), query departures for how many minutes from now?
       - name: "Stargarder Str." # currently you have to add more than one stop to track
         stop_id: 900000110501
-        # direction: 900000100002 # Optional stop_id to limit departures for a specific direction (same URL as to find the stop_id)
+        # direction: 900000100002 # Optional stop_id to limit departures for a specific direction (same URL as to find the stop_id), multiple Values can be specified using a comma separated list
         # walking_time: 5 # Optional parameter with value in minutes that hide transport closer than N minutes
         # show_official_line_colors: true # Optionally enable official VBB line colors. By default predefined colors will be used.
         # duration: 30 # Optional (default 10), query departures for how many minutes from now?

--- a/custom_components/berlin_transport/departure.py
+++ b/custom_components/berlin_transport/departure.py
@@ -62,3 +62,14 @@ class Departure:
             "delay": self.delay,
             "walking_time": walking_time,
         }
+
+    # Make the object hashable and use all infos that can be displayed in the
+    # frontend
+    def __hash__(self):
+        # The value of colors and walking time doesn't matter, it just needs to
+        # be the same for all evaluations of this function
+        items = self.to_dict(show_api_line_colors=False, walking_time=0).items()
+        # Dictionaries are not hashable, so use the items, sort them for
+        # reproducibility. Convert it to a tuple, since lists are also not
+        # hashable
+        return hash(tuple(sorted(items)))


### PR DESCRIPTION
This allows specifying multiple directions by separating them with commas. This allows to only see the directions you want to see. E.g. only inwards town and along the Ring at Schönhauser Allee.

For each direction, the departures will be fetched individually and collected together.

Since S41/S42 show up for both directions on the Ring, the departures have to de-duplicated, for which I used a set and made Departure hashable. The hash is calculated over all information exposed in to_dict, since that's everything, which users have access to over the sensor.