### PR TITLE
Use session for connection pooling

### DIFF
--- a/custom_components/berlin_transport/sensor.py
+++ b/custom_components/berlin_transport/sensor.py
@@ -107,6 +107,7 @@ class TransportSensor(SensorEntity):
         self.walking_time: int = config.get(CONF_DEPARTURES_WALKING_TIME) or 1
         # we add +1 minute anyway to delete the "just gone" transport
         self.show_api_line_colors: bool = config.get(CONF_SHOW_API_LINE_COLORS) or False
+        self.session: requests.Session = requests.Session()
 
     @property
     def name(self) -> str:
@@ -144,7 +145,7 @@ class TransportSensor(SensorEntity):
 
     def fetch_directional_departure(self, direction: str | None) -> list[Departure]:
         try:
-            response = requests.get(
+            response = self.session.get(
                 url=f"{API_ENDPOINT}/stops/{self.stop_id}/departures",
                 params={
                     "when": (


### PR DESCRIPTION
This avoids creating a new connection for each request.

If desired, we can optimize further with https://pypi.org/project/requests-cache/ which supports cachecontrol tags.