### PR TITLE
Add requests-cache

### DIFF
--- a/custom_components/berlin_transport/manifest.json
+++ b/custom_components/berlin_transport/manifest.json
@@ -9,7 +9,7 @@
   "integration_type": "service",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/vas3k/home-assistant-berlin-transport/issues",
-  "requirements": [],
+  "requirements": ["requests", "requests-cache"],
   "ssdp": [],
   "version": "0.1.0",
   "zeroconf": []


### PR DESCRIPTION
This uses cache control and etags that upstream API supports


This still needs some testing.