### PR TITLE
Change requests-cache parameters

### DIFF
--- a/custom_components/berlin_transport/sensor.py
+++ b/custom_components/berlin_transport/sensor.py
@@ -6,7 +6,7 @@ import logging
 from datetime import datetime, timedelta
 
 from requests.exceptions import HTTPError, InvalidJSONError, Timeout
-from requests_cache import CachedSession
+from requests_cache import CachedSession, SQLiteCache
 import voluptuous as vol
 
 from homeassistant.core import HomeAssistant
@@ -105,7 +105,11 @@ class TransportSensor(SensorEntity):
         self.walking_time: int = config.get(CONF_DEPARTURES_WALKING_TIME) or 1
         # we add +1 minute anyway to delete the "just gone" transport
         self.show_api_line_colors: bool = config.get(CONF_SHOW_API_LINE_COLORS) or False
-        self.session: CachedSession = CachedSession("berlin-transport", cache_control=True)
+        self.session: CachedSession = CachedSession(
+            backend=SQLiteCache(use_memory=True), 
+            cache_control=True, 
+            expire_after=timedelta(days=1)
+        )
 
     @property
     def name(self) -> str:


### PR DESCRIPTION
This should fix #44 

The request-cache sqlite db now resides in memory. This also helps reduce constant storage writes to disk.
The requests expire after 1 day. The expiration is preceded by the http-headers ([requests-cache expiration-precedence](https://requests-cache.readthedocs.io/en/stable/user_guide/expiration.html#expiration-precedence)).
