### PR TITLE
fix: change request caching to in-memory BaseCache

### DIFF
--- a/custom_components/berlin_transport/sensor.py
+++ b/custom_components/berlin_transport/sensor.py
@@ -105,7 +105,11 @@ class TransportSensor(SensorEntity):
         self.walking_time: int = config.get(CONF_DEPARTURES_WALKING_TIME) or 1
         # we add +1 minute anyway to delete the "just gone" transport
         self.show_api_line_colors: bool = config.get(CONF_SHOW_API_LINE_COLORS) or False
-        self.session: CachedSession = CachedSession("berlin-transport", cache_control=True)
+        self.session: CachedSession = CachedSession(
+            backend='memory',
+            cache_control=True,
+            expire_after=timedelta(days=1)
+        )
 
     @property
     def name(self) -> str:


### PR DESCRIPTION
This introduces BaseCache to prevent storage path and locking issues in the requests-cache.

#46 #44 