### PR TITLE
Fall back to BVG endpoint on VBB TLS/connection failures

### DIFF
--- a/custom_components/berlin_transport/const.py
+++ b/custom_components/berlin_transport/const.py
@@ -9,6 +9,10 @@ CONF_UNIQUE_ID = "unique_id"
 DEFAULT_SCAN_INTERVAL = 90  # seconds
 DEFAULT_FALLBACK_TIME = 15  # minutes
 DEFAULT_API_ENDPOINT = "https://v6.vbb.transport.rest"
+# BVG's own HAFAS instance covers the same VBB-area stop IDs and serves as a
+# fallback when the configured endpoint is unreachable at the connection/TLS
+# level (e.g. TLS handshake failures observed on v6.vbb.transport.rest).
+DEFAULT_API_ENDPOINT_FALLBACK = "https://v6.bvg.transport.rest"
 DEFAULT_API_MAX_RESULTS = 15
 
 # Option keys (stored in ConfigEntry.options, edited via the options flow)

--- a/custom_components/berlin_transport/sensor.py
+++ b/custom_components/berlin_transport/sensor.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import logging
+import ssl
 from datetime import datetime, timedelta
 from typing import Any, Mapping
 
@@ -44,6 +45,7 @@ from .const import (
     CONF_TYPE_TRAM,
     CONF_UNIQUE_ID,
     DEFAULT_API_ENDPOINT,
+    DEFAULT_API_ENDPOINT_FALLBACK,
     DEFAULT_API_MAX_RESULTS,
     DEFAULT_FALLBACK_TIME,
     DEFAULT_ICON,
@@ -132,6 +134,13 @@ class TransportSensor(SensorEntity):
         self.config = config
         self._entry_id = entry_id
         self.api_endpoint: str = config.get(CONF_API_ENDPOINT) or DEFAULT_API_ENDPOINT
+        # Only used when it actually differs from the configured endpoint,
+        # so a user who already points at the fallback isn't retried against it.
+        self.api_endpoint_fallback: str | None = (
+            DEFAULT_API_ENDPOINT_FALLBACK
+            if self.api_endpoint != DEFAULT_API_ENDPOINT_FALLBACK
+            else None
+        )
         self.api_max_results: int = (
             config.get(CONF_API_MAX_RESULTS) or DEFAULT_API_MAX_RESULTS
         )
@@ -206,40 +215,66 @@ class TransportSensor(SensorEntity):
             self.departures = departures
             self.last_update_success = current_time
 
-    async def fetch_directional_departure(
-        self, direction: str | None
-    ) -> list[Departure] | None:
-        try:
-            params: dict[str, Any] = {
-                "when": (
-                    datetime.now().astimezone() + timedelta(minutes=self.walking_time)
-                ).isoformat(),
-                "results": self.api_max_results,
-                "suburban": str(self.config.get(CONF_TYPE_SUBURBAN) or False).lower(),
-                "subway": str(self.config.get(CONF_TYPE_SUBWAY) or False).lower(),
-                "tram": str(self.config.get(CONF_TYPE_TRAM) or False).lower(),
-                "bus": str(self.config.get(CONF_TYPE_BUS) or False).lower(),
-                "ferry": str(self.config.get(CONF_TYPE_FERRY) or False).lower(),
-                "express": str(self.config.get(CONF_TYPE_EXPRESS) or False).lower(),
-                "regional": str(self.config.get(CONF_TYPE_REGIONAL) or False).lower(),
-            }
-            if self.duration is not None:
-                params["duration"] = self.duration
-            if direction is not None:
-                params["direction"] = direction
+    async def _request_departures(self, endpoint: str, params: dict[str, Any]) -> dict:
+        async with async_timeout.timeout(30):
+            response = await self.session.get(
+                url=f"{endpoint}/stops/{self.stop_id}/departures",
+                params=params,
+            )
+            response.raise_for_status()
+            return await response.json()
 
-            async with async_timeout.timeout(30):
-                response = await self.session.get(
-                    url=f"{self.api_endpoint}/stops/{self.stop_id}/departures",
-                    params=params,
-                )
-                response.raise_for_status()
-                departures = await response.json()
+    async def _request_departures_with_fallback(
+        self, params: dict[str, Any]
+    ) -> dict | None:
+        try:
+            return await self._request_departures(self.api_endpoint, params)
+        except (aiohttp.ClientConnectionError, ssl.SSLError) as ex:
+            if self.api_endpoint_fallback is None:
+                _LOGGER.warning(f"API connection error: {ex}")
+                return None
+            _LOGGER.warning(
+                f"API connection error on {self.api_endpoint}, falling back to "
+                f"{self.api_endpoint_fallback}: {ex}"
+            )
         except aiohttp.ClientError as ex:
             _LOGGER.warning(f"API error: {ex}")
             return None
-        except Exception as ex:
+        except Exception as ex:  # pylint: disable=broad-except
             _LOGGER.error(f"Unexpected error: {ex}")
+            return None
+
+        try:
+            return await self._request_departures(self.api_endpoint_fallback, params)
+        except aiohttp.ClientError as ex:
+            _LOGGER.warning(f"API error on fallback endpoint: {ex}")
+        except Exception as ex:  # pylint: disable=broad-except
+            _LOGGER.error(f"Unexpected error on fallback endpoint: {ex}")
+        return None
+
+    async def fetch_directional_departure(
+        self, direction: str | None
+    ) -> list[Departure] | None:
+        params: dict[str, Any] = {
+            "when": (
+                datetime.now().astimezone() + timedelta(minutes=self.walking_time)
+            ).isoformat(),
+            "results": self.api_max_results,
+            "suburban": str(self.config.get(CONF_TYPE_SUBURBAN) or False).lower(),
+            "subway": str(self.config.get(CONF_TYPE_SUBWAY) or False).lower(),
+            "tram": str(self.config.get(CONF_TYPE_TRAM) or False).lower(),
+            "bus": str(self.config.get(CONF_TYPE_BUS) or False).lower(),
+            "ferry": str(self.config.get(CONF_TYPE_FERRY) or False).lower(),
+            "express": str(self.config.get(CONF_TYPE_EXPRESS) or False).lower(),
+            "regional": str(self.config.get(CONF_TYPE_REGIONAL) or False).lower(),
+        }
+        if self.duration is not None:
+            params["duration"] = self.duration
+        if direction is not None:
+            params["direction"] = direction
+
+        departures = await self._request_departures_with_fallback(params)
+        if departures is None:
             return None
 
         if not departures or "departures" not in departures:


### PR DESCRIPTION
## Summary

`v6.vbb.transport.rest` has started failing TLS handshakes for me (`SSLError: [SSL: TLSV1_ALERT_INTERNAL_ERROR] tlsv1 alert internal error`), on every stop ID, over both IPv4 and IPv6, reproducibly from a clean network path. It looks like a problem with that specific vhost on the transport.rest infrastructure rather than anything client-side — `v6.bvg.transport.rest` (same transport.rest backend, BVG's own HAFAS instance) responds normally and serves the same VBB-area stop IDs, since BVG's network covers Berlin including VBB S-/U-Bahn.

With the primary endpoint down, `TransportSensor` currently goes `unavailable` (after the existing 15-minute `FALLBACK_TIME` grace period lapses), which breaks all departure sensors.

This PR adds a fallback: when the request to `API_ENDPOINT` fails at the connection/TLS level (`aiohttp.ClientConnectionError` or `ssl.SSLError`), retry the same request against `API_ENDPOINT_FALLBACK` (`v6.bvg.transport.rest`) before giving up. Ordinary HTTP-level errors (4xx/5xx, timeouts) are left untouched — those already surface a warning and return `None` as before, since they indicate the endpoint is reachable but erroring, not a network-level failure.

## Changes

- `const.py`: add `API_ENDPOINT_FALLBACK = "https://v6.bvg.transport.rest"`
- `sensor.py`: extract the request into `_request_departures(endpoint, params)`, and in `fetch_directional_departure` retry against the fallback endpoint on connection/SSL errors before returning `None`

## Test plan

- [x] Reproduced the VBB TLS failure directly with `curl` (both IPv4 and IPv6) and confirmed `v6.bvg.transport.rest` responds normally for the same stop IDs
- [x] Deployed this patch to a live Home Assistant instance; confirmed via logs that the integration falls back to `v6.bvg.transport.rest` on every poll while VBB is down, with departures served successfully (no more `unavailable` sensors)
- [x] `python3 -m py_compile` on the changed files