### PR TITLE
refactor: Convert comma-separated lists to actual lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ Repeat for every stop you want. All stops under one hub share the same API endpo
 | Setting                               | Default | Description |
 | ------------------------------------- | ------- | ----------- |
 | Walking time in minutes               | `1`     | Time needed to walk to the stop. Departures you could not reach in time are hidden. |
-| Filter departures by direction        | not set | Comma-separated list of `stop_id`s along the intended lines, or their final destinations. See [How do I find my stop_id?](#how-do-i-find-my-stop_id). |
-| Exclude nearby stops with IDs         | not set | Comma-separated list of `stop_id`s to drop from the results. Use this when the API returns departures from nearby stops. |
-| Exclude lines by name                 | not set | Comma-separated list of line names, e.g. `S41`. |
+| Filter departures by direction        | not set | `stop_id`s along the intended lines, or their final destinations. Add one value per entry. See [How do I find my stop_id?](#how-do-i-find-my-stop_id). |
+| Exclude nearby stops with IDs         | not set | `stop_id`s to drop from the results. Add one value per entry. Use this when the API returns departures from nearby stops. |
+| Exclude lines by name                 | not set | Line names to drop from the results, e.g. `S41`. Add one value per entry. |
 | Show departures for how many minutes? | not set | How far into the future to fetch departures. Leave empty to use the API's own default window. |
 | Enable official VBB line colors       | off     | Use the colors reported by the API instead of the predefined ones. |
 | Transport types                       | all on  | Which products to include: S-Bahn, U-Bahn, Tram, Bus, Ferry, IC/ICE, RB/RE. |
@@ -81,6 +81,7 @@ A home assistant addon for the server is also available at https://github.com/Co
 
 Older versions created **one config entry per stop**. On first start after the update, all of those entries are migrated automatically into a **single hub**, with each old entry becoming a stop underneath it. Your entities keep their IDs, so history and dashboards are unaffected.
 
+The direction and exclusion filters used to be stored as a single comma-separated string. They are now lists, and existing stops are converted automatically on the same first start. Only [YAML configurations](#-yaml-configuration-legacy) have to be updated by hand.
 
 Downgrading to a pre-hub version is not supported; the config entries cannot be converted back.
 
@@ -94,20 +95,28 @@ sensor:
     departures:
       - name: "S+U Schönhauser Allee" # free-form name, only for display purposes
         stop_id: 900110001 # actual Stop ID for the API
-        # direction: 900110002,900007102 # Optional stop_id to limit departures for a specific direction (same URL as to find the stop_id), multiple Values can be specified using a comma separated list
-        # excluded_lines: S41 # Optional comma separated list of line names to exclude
+        # direction: # Optional list of stop_ids to limit departures for specific directions (same URL as to find the stop_id)
+        #   - 900110002
+        #   - 900007102
+        # excluded_lines: # Optional list of line names to exclude
+        #   - S41
         # walking_time: 5 # Optional parameter with value in minutes that hides transport closer than N minutes
         # suburban: false # Optionally hide transport options
         # show_official_line_colors: true # Optionally enable official VBB line colors. By default predefined colors will be used.
         # duration: 30 # Optional (default 10), query departures for how many minutes from now?
       - name: "Stargarder Str." # currently you have to add more than one stop to track
         stop_id: 900000110501
-        # direction: 900000100002 # Optional stop_id to limit departures for a specific direction (same URL as to find the stop_id), multiple Values can be specified using a comma separated list
-        # excluded_stops: 900110502,900007102 # Exclude these stop IDs from the departures, duplicate departures may be shown for nearby stations
+        # direction: # Optional list of stop_ids to limit departures for specific directions (same URL as to find the stop_id)
+        #   - 900000100002
+        # excluded_stops: # Exclude these stop IDs from the departures, duplicate departures may be shown for nearby stations
+        #   - 900110502
+        #   - 900007102
         # walking_time: 5 # Optional parameter with value in minutes that hide transport closer than N minutes
         # show_official_line_colors: true # Optionally enable official VBB line colors. By default predefined colors will be used.
         # duration: 30 # Optional (default 10), query departures for how many minutes from now?
 ```
+
+`direction`, `excluded_stops` and `excluded_lines` used to be written as a single comma-separated string (`excluded_lines: S41,S42`). That form still works, but it is deprecated and will be removed in a future release — Home Assistant raises a repair notice under `Settings` → `Devices & services` → `Repairs` naming the stops that still use it. Rewrite each of them as a list as shown above and restart. A single value can stay a plain scalar (`excluded_lines: S41`).
 
 To install manually, copy the whole [berlin_transport](./custom_components/) directory into the `custom_components` folder of your Home Assistant installation (create it next to `configuration.yaml` if it doesn't exist), then restart Home Assistant.
 

--- a/custom_components/berlin_transport/__init__.py
+++ b/custom_components/berlin_transport/__init__.py
@@ -17,9 +17,11 @@ from .const import (
     CONF_API_MAX_RESULTS,
     CONF_FALLBACK_TIME,
     CONF_UNIQUE_ID,
+    CONFIG_ENTRY_VERSION,
     DEFAULT_API_ENDPOINT,
     SUBENTRY_TYPE_STOP,
 )
+from .helpers import normalized_list_options
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -37,16 +39,24 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 
 async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Migrate v1 (one entry per stop) to v2 (one hub entry + stop subentries).
+    """Migrate an entry to the current version.
 
-    All v1 entries end up in a single hub: the first one to be migrated becomes
-    that hub, every later one hands its stop over as a subentry and is removed.
-    The shared settings of that first entry become the hub's and from then on
-    apply to every stop under it.
+    v1 -> v2: one entry per stop becomes a single hub entry with one subentry
+    per stop. All v1 entries end up in a single hub: the first one to be
+    migrated becomes that hub, every later one hands its stop over as a
+    subentry and is removed. The shared settings of that first entry become the
+    hub's and from then on apply to every stop under it.
+
+    v2 -> v3: the options that used to hold a comma-separated string become
+    real lists of strings.
     """
-    if entry.version > 2:
+    if entry.version > CONFIG_ENTRY_VERSION:
         # Downgrade is not supported.
         return False
+
+    if entry.version == 2:
+        _migrate_lists(hass, entry)
+        return True
 
     if entry.version != 1:
         return True
@@ -55,6 +65,9 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hub_settings = {key: old[key] for key in _HUB_KEYS if key in old}
     # The remaining keys describe the single stop this entry used to be.
     stop_data = {k: v for k, v in old.items() if k not in _HUB_KEYS}
+    # v1 predates the list options, so bring the stop straight to v3 shape: it
+    # may well be handed to a hub that has already been migrated.
+    stop_data.update(normalized_list_options(stop_data))
     # Preserve the existing entity identity (was keyed on the entry id).
     stop_data[CONF_UNIQUE_ID] = entry.entry_id
     stop_title = entry.title
@@ -68,7 +81,7 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             data={},
             options=hub_settings,
             title=hub_settings.get(CONF_API_ENDPOINT) or DEFAULT_API_ENDPOINT,
-            version=2,
+            version=CONFIG_ENTRY_VERSION,
         )
         hub = entry
 
@@ -98,6 +111,21 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     _LOGGER.info("Migrated %s into the %s hub", stop_title, hub.title)
     return True
+
+
+def _migrate_lists(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Rewrite every stop's comma-separated string options as lists of strings."""
+    for subentry in list(entry.subentries.values()):
+        if subentry.subentry_type != SUBENTRY_TYPE_STOP:
+            continue
+        hass.config_entries.async_update_subentry(
+            entry,
+            subentry,
+            data={**subentry.data, **normalized_list_options(subentry.data)},
+        )
+
+    hass.config_entries.async_update_entry(entry, version=CONFIG_ENTRY_VERSION)
+    _LOGGER.info("Migrated the %s hub to list-valued stop options", entry.title)
 
 
 def _existing_hub(hass: HomeAssistant, entry: ConfigEntry) -> ConfigEntry | None:

--- a/custom_components/berlin_transport/config_flow.py
+++ b/custom_components/berlin_transport/config_flow.py
@@ -27,6 +27,7 @@ from .const import (
     CONF_FALLBACK_TIME,
     CONF_SELECTED_STOP,
     CONF_SHOW_API_LINE_COLORS,
+    CONFIG_ENTRY_VERSION,
     DEFAULT_API_ENDPOINT,
     DEFAULT_API_MAX_RESULTS,
     DEFAULT_FALLBACK_TIME,
@@ -53,11 +54,30 @@ HUB_SCHEMA = vol.Schema(
     }
 )
 
+
+def string_list_selector() -> selector.TextSelector:
+    """Free-form multi-value input, one text field per value.
+
+    The frontend repeats the field label on every row, so the labels of the
+    options using this are phrased in the singular.
+    """
+    return selector.TextSelector(selector.TextSelectorConfig(multiple=True))
+
+
 DATA_SCHEMA = vol.Schema(
     {
-        vol.Optional(CONF_DEPARTURES_DIRECTION): cv.string,
-        vol.Optional(CONF_DEPARTURES_EXCLUDED_STOPS): cv.string,
-        vol.Optional(CONF_DEPARTURES_EXCLUDED_LINES): cv.string,
+        vol.Optional(
+            CONF_DEPARTURES_DIRECTION,
+            default=list,
+        ): string_list_selector(),
+        vol.Optional(
+            CONF_DEPARTURES_EXCLUDED_STOPS,
+            default=list,
+        ): string_list_selector(),
+        vol.Optional(
+            CONF_DEPARTURES_EXCLUDED_LINES,
+            default=list,
+        ): string_list_selector(),
         vol.Optional(CONF_DEPARTURES_DURATION): cv.positive_int,
         vol.Optional(CONF_DEPARTURES_WALKING_TIME, default=1): cv.positive_int,
         vol.Optional(CONF_SHOW_API_LINE_COLORS, default=False): cv.boolean,
@@ -135,7 +155,7 @@ class TransportConfigFlowHandler(
     by the user, never through discovery.
     """
 
-    VERSION = 2
+    VERSION = CONFIG_ENTRY_VERSION
 
     CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
 

--- a/custom_components/berlin_transport/const.py
+++ b/custom_components/berlin_transport/const.py
@@ -1,5 +1,8 @@
 DOMAIN = "berlin_transport"
 
+# Current config entry version, bumped whenever the stored data changes shape.
+CONFIG_ENTRY_VERSION = 3
+
 # Subentry type for stops added under a hub entry.
 SUBENTRY_TYPE_STOP = "stop"
 # Stable entity unique id, stored in subentry data (preserved across migration).
@@ -28,6 +31,22 @@ CONF_DEPARTURES_WALKING_TIME = "walking_time"
 CONF_DEPARTURES_DIRECTION = "direction"
 CONF_DEPARTURES_DURATION = "duration"
 CONF_SHOW_API_LINE_COLORS = "show_official_line_colors"
+
+# Per-stop options holding a list of strings. Up to config entry version 2 each
+# of these was stored as a single comma-separated string instead.
+CONF_LIST_OPTIONS = (
+    CONF_DEPARTURES_DIRECTION,
+    CONF_DEPARTURES_EXCLUDED_STOPS,
+    CONF_DEPARTURES_EXCLUDED_LINES,
+)
+
+# Repair issue raised while a YAML config still uses the comma-separated form.
+ISSUE_YAML_CSV_LISTS = "yaml_comma_separated_lists"
+YAML_DOCS_URL = (
+    "https://github.com/vas3k/home-assistant-berlin-transport"
+    "#-yaml-configuration-legacy"
+)
+
 CONF_TYPE_SUBURBAN = "suburban"
 CONF_TYPE_SUBWAY = "subway"
 CONF_TYPE_TRAM = "tram"

--- a/custom_components/berlin_transport/helpers.py
+++ b/custom_components/berlin_transport/helpers.py
@@ -1,0 +1,36 @@
+"""Shared helpers for the Berlin (BVG) and Brandenburg (VBB) transport integration."""
+
+from typing import Any, Mapping
+
+from .const import CONF_LIST_OPTIONS
+
+
+def as_string_list(value: Any) -> list[str]:
+    """Normalize a list option into a list of non-empty strings.
+
+    A plain string is read as the legacy comma-separated form, so YAML configs
+    written before the switch to lists keep working.
+    """
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return value.split(",")
+    if isinstance(value, list):
+        return value
+    if isinstance(value, tuple):
+        return list(value)
+    return [value]
+
+
+def is_legacy_csv(value: Any) -> bool:
+    """Whether a value still uses the comma-separated string form."""
+    return isinstance(value, str) and "," in value
+
+
+def normalized_list_options(data: Mapping[str, Any]) -> dict[str, list[str]]:
+    """The list options of `data`, normalized to lists of strings.
+
+    Only options actually present are returned, so the result can be merged
+    into stored data without introducing keys the user never set.
+    """
+    return {key: as_string_list(data[key]) for key in CONF_LIST_OPTIONS if key in data}

--- a/custom_components/berlin_transport/sensor.py
+++ b/custom_components/berlin_transport/sensor.py
@@ -12,7 +12,8 @@ import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
 from homeassistant.components.sensor import PLATFORM_SCHEMA, SensorEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity_platform import (
     AddConfigEntryEntitiesCallback,
@@ -32,6 +33,7 @@ from .const import (
     CONF_DEPARTURES_STOP_ID,
     CONF_DEPARTURES_WALKING_TIME,
     CONF_FALLBACK_TIME,
+    CONF_LIST_OPTIONS,
     CONF_SHOW_API_LINE_COLORS,
     CONF_TYPE_BUS,
     CONF_TYPE_EXPRESS,
@@ -46,9 +48,13 @@ from .const import (
     DEFAULT_FALLBACK_TIME,
     DEFAULT_ICON,
     DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
+    ISSUE_YAML_CSV_LISTS,
     SUBENTRY_TYPE_STOP,
+    YAML_DOCS_URL,
 )
 from .departure import Departure
+from .helpers import as_string_list, is_legacy_csv
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -65,15 +71,20 @@ TRANSPORT_TYPES_SCHEMA = {
     vol.Optional(CONF_TYPE_REGIONAL, default=True): cv.boolean,
 }
 
+# A list of strings, or the legacy comma-separated string it replaced. The
+# legacy form is validated but not accepted silently: see
+# `async_report_legacy_csv_lists` below.
+STRING_LIST_SCHEMA = vol.Any(cv.string, [cv.string])
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Optional(CONF_DEPARTURES): [
             {
                 vol.Required(CONF_DEPARTURES_NAME): cv.string,
                 vol.Required(CONF_DEPARTURES_STOP_ID): cv.positive_int,
-                vol.Optional(CONF_DEPARTURES_DIRECTION): cv.string,
-                vol.Optional(CONF_DEPARTURES_EXCLUDED_STOPS): cv.string,
-                vol.Optional(CONF_DEPARTURES_EXCLUDED_LINES): cv.string,
+                vol.Optional(CONF_DEPARTURES_DIRECTION): STRING_LIST_SCHEMA,
+                vol.Optional(CONF_DEPARTURES_EXCLUDED_STOPS): STRING_LIST_SCHEMA,
+                vol.Optional(CONF_DEPARTURES_EXCLUDED_LINES): STRING_LIST_SCHEMA,
                 vol.Optional(CONF_DEPARTURES_DURATION): cv.positive_int,
                 vol.Optional(CONF_DEPARTURES_WALKING_TIME, default=1): cv.positive_int,
                 vol.Optional(CONF_SHOW_API_LINE_COLORS, default=False): cv.boolean,
@@ -82,6 +93,43 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         ]
     }
 )
+
+
+@callback
+def async_report_legacy_csv_lists(
+    hass: HomeAssistant, departures: list[Mapping[str, Any]]
+) -> None:
+    """Raise a repair issue for YAML stops still using comma-separated strings.
+
+    Config entries are migrated in place, but YAML is read back from
+    `configuration.yaml` on every start, so it can only be pointed at the stops
+    that need editing. The issue is not persistent: it is re-raised on the next
+    start iff the old form is still there.
+    """
+    stops: set[str] = set()
+    options: set[str] = set()
+    for departure in departures:
+        legacy = [key for key in CONF_LIST_OPTIONS if is_legacy_csv(departure.get(key))]
+        if legacy:
+            stops.add(departure[CONF_DEPARTURES_NAME])
+            options.update(legacy)
+
+    if not stops:
+        return
+
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        ISSUE_YAML_CSV_LISTS,
+        is_fixable=False,
+        severity=ir.IssueSeverity.WARNING,
+        translation_key=ISSUE_YAML_CSV_LISTS,
+        translation_placeholders={
+            "stops": ", ".join(sorted(stops)),
+            "options": ", ".join(sorted(options)),
+        },
+        learn_more_url=YAML_DOCS_URL,
+    )
 
 
 # Kept here for backwards compatability with yaml users
@@ -93,6 +141,7 @@ async def async_setup_platform(
 ) -> None:
     """Set up the sensor platform."""
     if CONF_DEPARTURES in config:
+        async_report_legacy_csv_lists(hass, config[CONF_DEPARTURES])
         for departure in config[CONF_DEPARTURES]:
             async_add_entities([TransportSensor(hass, departure)], True)
 
@@ -137,10 +186,12 @@ class TransportSensor(SensorEntity):
             minutes=config.get(CONF_FALLBACK_TIME) or DEFAULT_FALLBACK_TIME
         )
         self.stop_id: int = config[CONF_DEPARTURES_STOP_ID]
-        self.excluded_stops: str | None = config.get(CONF_DEPARTURES_EXCLUDED_STOPS)
-        self.excluded_lines: str | None = config.get(CONF_DEPARTURES_EXCLUDED_LINES)
+        # Config entries store these as lists; YAML may still hold the legacy
+        # comma-separated string, which `as_string_list` splits for us.
+        self.excluded_stops = as_string_list(config.get(CONF_DEPARTURES_EXCLUDED_STOPS))
+        self.excluded_lines = as_string_list(config.get(CONF_DEPARTURES_EXCLUDED_LINES))
         self.sensor_name: str | None = config.get(CONF_DEPARTURES_NAME)
-        self.direction: str | None = config.get(CONF_DEPARTURES_DIRECTION)
+        self.directions = as_string_list(config.get(CONF_DEPARTURES_DIRECTION))
         self.duration: int | None = config.get(CONF_DEPARTURES_DURATION)
         self.walking_time: int = config.get(CONF_DEPARTURES_WALKING_TIME) or 1
         # we add +1 minute anyway to delete the "just gone" transport
@@ -244,38 +295,25 @@ class TransportSensor(SensorEntity):
             _LOGGER.warning(f"No departures found for {self.stop_id}")
             return []
 
-        if self.excluded_stops is None:
-            excluded_stops = []
-        else:
-            excluded_stops = self.excluded_stops.split(",")
-
-        if self.excluded_lines is None:
-            excluded_lines = []
-        else:
-            excluded_lines = self.excluded_lines.split(",")
-
         # convert api data into objects
         return [
             Departure.from_dict(departure)
             for departure in (departures.get("departures") or [])
-            if departure.get("stop", {}).get("id") not in excluded_stops
-            and departure.get("line", {}).get("name") not in excluded_lines
+            if departure.get("stop", {}).get("id") not in self.excluded_stops
+            and departure.get("line", {}).get("name") not in self.excluded_lines
         ]
 
     async def fetch_departures(self) -> list[Departure] | None:
         departures = []
 
-        if self.direction is None:
-            res = await self.fetch_directional_departure(self.direction)
+        # If no direction filter is set, set the directions to [None], so
+        # we make one request with no direction filter.
+        directions: list[str] | list[None] = self.directions or [None]
+        for direction in directions:
+            res = await self.fetch_directional_departure(direction)
             if res is None:
                 return None
             departures += res
-        else:
-            for direction in self.direction.split(","):
-                res = await self.fetch_directional_departure(direction)
-                if res is None:
-                    return None
-                departures += res
 
         # Get rid of duplicates
         # Duplicates should only exist for the Ringbahn and filtering for both

--- a/custom_components/berlin_transport/strings.json
+++ b/custom_components/berlin_transport/strings.json
@@ -38,11 +38,16 @@
         "details": {
           "title": "Further Details",
           "description": "Add further details",
+          "data_description": {
+            "direction": "Only show departures that pass or end at any of these stops. Leave empty for all directions. Enter a single stop id each.",
+            "excluded_stops": "Drop departures for these nearby stops. Enter a single stop id each.",
+            "excluded_lines": "Drop these lines from the results, e.g. S41."
+          },
           "data": {
             "walking_time": "Walking time in minutes",
-            "direction": "Filter departures by direction",
-            "excluded_stops": "Exclude nearby stops with IDs",
-            "excluded_lines": "Exclude Lines by name",
+            "direction": "Direction filter",
+            "excluded_stops": "Ignored nearby stop",
+            "excluded_lines": "Ignored line",
             "show_official_line_colors": "Enable official VBB line colors",
             "duration": "Show departures for how many minutes?",
             "suburban": "Include S-Bahn",
@@ -57,11 +62,16 @@
         "reconfigure": {
           "title": "Reconfigure",
           "description": "Update sensor settings",
+          "data_description": {
+            "direction": "Only show departures that pass or end at any of these stops. Leave empty for all directions. Enter a single stop id each.",
+            "excluded_stops": "Drop departures for these nearby stops. Enter a single stop id each.",
+            "excluded_lines": "Drop these lines from the results, e.g. S41."
+          },
           "data": {
             "walking_time": "Walking time in minutes",
-            "direction": "Filter departures by direction",
-            "excluded_stops": "Exclude nearby stops with IDs",
-            "excluded_lines": "Exclude Lines by name",
+            "direction": "Direction filter",
+            "excluded_stops": "Ignored nearby stop",
+            "excluded_lines": "Ignored line",
             "show_official_line_colors": "Enable official VBB line colors",
             "duration": "Show departures for how many minutes?",
             "suburban": "Include S-Bahn",
@@ -87,6 +97,12 @@
           "fallback_time": "Fallback time in minutes (keep showing last results when the API is unavailable)"
         }
       }
+    }
+  },
+  "issues": {
+    "yaml_comma_separated_lists": {
+      "title": "Comma-separated lists in the YAML configuration",
+      "description": "The YAML configuration of {stops} still sets {options} as a comma-separated string. These options now take a list of values, and support for the comma-separated form will be removed in a future release.\n\nEdit `configuration.yaml` and write each value as its own list item, e.g.:\n\n```yaml\nsensor:\n  - platform: berlin_transport\n    departures:\n      - name: \"S+U Schönhauser Allee\"\n        stop_id: 900110001\n        excluded_lines:\n          - S41\n          - S42\n```\n\nRestart Home Assistant afterwards. This notice does not come back once no stop uses the old form."
     }
   }
 }

--- a/custom_components/berlin_transport/translations/de.json
+++ b/custom_components/berlin_transport/translations/de.json
@@ -38,11 +38,16 @@
         "details": {
           "title": "Weitere Details",
           "description": "Zusätzliche Einstellungen",
+          "data_description": {
+            "direction": "Nur Abfahrten anzeigen, die an diesen Haltestellen halten oder dort enden. Leer lassen für keinen Filter. Eine Haltestellen-ID pro Eintrag.",
+            "excluded_stops": "Abfahrten für diese nahegelegenen Haltestellen ausblenden. Eine Haltestellen-ID pro Eintrag.",
+            "excluded_lines": "Diese Linien aus den Ergebnissen entfernen, z. B. S41."
+          },
           "data": {
             "walking_time": "Gehminuten zur Haltestelle",
-            "direction": "Nur Abfahrten zu diesen (End-)Haltestellen",
-            "excluded_stops": "Diese nahegelegenen Haltestellen ignorieren",
-            "excluded_lines": "Diese Linien ignorieren",
+            "direction": "Zwischenstopp Filter",
+            "excluded_stops": "Ignorierte Haltestellen",
+            "excluded_lines": "Ignorierte Linie",
             "show_official_line_colors": "Offizielle VBB-Farben verwenden",
             "duration": "Zeitraum für Abfahrten (Minuten)",
             "suburban": "S-Bahn anzeigen",
@@ -57,11 +62,16 @@
         "reconfigure": {
           "title": "Neu konfigurieren",
           "description": "Sensoreinstellungen bearbeiten",
+          "data_description": {
+            "direction": "Nur Abfahrten anzeigen, die an diesen Haltestellen halten oder dort enden. Leer lassen für keinen Filter. Eine Haltestellen-ID pro Eintrag.",
+            "excluded_stops": "Abfahrten für diese nahegelegenen Haltestellen entfernen. Eine Haltestellen-ID pro Eintrag.",
+            "excluded_lines": "Diese Linien aus den Ergebnissen entfernen, z. B. S41."
+          },
           "data": {
             "walking_time": "Gehminuten zur Haltestelle",
-            "direction": "Nur Abfahrten zu diesen (End-)Haltestellen",
-            "excluded_stops": "Diese nahegelegenen Haltestellen ignorieren",
-            "excluded_lines": "Diese Linien ignorieren",
+            "direction": "Zwischenstopp Filter",
+            "excluded_stops": "Ignorierte Haltestellen",
+            "excluded_lines": "Ignorierte Linie",
             "show_official_line_colors": "Offizielle VBB-Farben verwenden",
             "duration": "Zeitraum für Abfahrten (Minuten)",
             "suburban": "S-Bahn anzeigen",
@@ -87,6 +97,12 @@
           "fallback_time": "Überbrückungszeit in Minuten (für diese Zeit werden die letzten Ergebnisse angezeigt, wenn die API nicht erreichbar ist)"
         }
       }
+    }
+  },
+  "issues": {
+    "yaml_comma_separated_lists": {
+      "title": "Kommagetrennte Listen in der YAML-Konfiguration",
+      "description": "In der YAML-Konfiguration von {stops} ist {options} noch über Kommata getrennt angegeben. Diese Optionen erwarten jetzt eine Liste von Werten, die kommagetrennte Schreibweise wird in einer künftigen Version entfernt werden.\n\nTrage in der `configuration.yaml` jeden Wert als eigenen Listeneintrag ein, z. B.:\n\n```yaml\nsensor:\n  - platform: berlin_transport\n    departures:\n      - name: \"S+U Schönhauser Allee\"\n        stop_id: 900110001\n        excluded_lines:\n          - S41\n          - S42\n```\n\nStarte Home Assistant anschließend neu. Der Hinweis erscheint nicht mehr, sobald keine Haltestelle das alte Format verwendet."
     }
   }
 }

--- a/custom_components/berlin_transport/translations/en.json
+++ b/custom_components/berlin_transport/translations/en.json
@@ -38,11 +38,16 @@
         "details": {
           "title": "More Details",
           "description": "Additional settings",
+          "data_description": {
+            "direction": "Only show departures that pass or end at any of these stops. Leave empty for all directions. Enter a single stop id each.",
+            "excluded_stops": "Drop departures that the API reports for these nearby stops. Enter a single stop id each.",
+            "excluded_lines": "Drop these lines from the results, e.g. S41."
+          },
           "data": {
             "walking_time": "Walking time to stop (minutes)",
-            "direction": "Only show departures which pass or end at these destinations",
-            "excluded_stops": "Ignore these nearby stop IDs",
-            "excluded_lines": "Ignore these lines",
+            "direction": "Direction filter",
+            "excluded_stops": "Ignored nearby stop",
+            "excluded_lines": "Ignored line",
             "show_official_line_colors": "Use official VBB line colors",
             "duration": "Departure time range (minutes)",
             "suburban": "Show S-Bahn",
@@ -57,11 +62,16 @@
         "reconfigure": {
           "title": "Reconfigure",
           "description": "Update sensor settings",
+          "data_description": {
+            "direction": "Only show departures that pass or end at any of these stops. Leave empty for all directions. Enter a single stop id each.",
+            "excluded_stops": "Drop departures that the API reports for these nearby stops. Enter a single stop id each.",
+            "excluded_lines": "Drop these lines from the results, e.g. S41."
+          },
           "data": {
             "walking_time": "Walking time to stop (minutes)",
-            "direction": "Only show departures which pass or end at these destinations",
-            "excluded_stops": "Ignore these nearby stop IDs",
-            "excluded_lines": "Ignore these lines",
+            "direction": "Direction filter",
+            "excluded_stops": "Ignored nearby stop",
+            "excluded_lines": "Ignored line",
             "show_official_line_colors": "Use official VBB line colors",
             "duration": "Departure time range (minutes)",
             "suburban": "Show S-Bahn",
@@ -87,6 +97,12 @@
           "fallback_time": "Fallback time in minutes (keep showing the last fetched departures for this time while the API is unavailable)"
         }
       }
+    }
+  },
+  "issues": {
+    "yaml_comma_separated_lists": {
+      "title": "Comma-separated lists in the YAML configuration",
+      "description": "The YAML configuration of {stops} still sets {options} as a comma-separated string. These options now take a list of values, and support for the comma-separated form will be removed in a future release.\n\nEdit `configuration.yaml` and write each value as its own list item, e.g.:\n\n```yaml\nsensor:\n  - platform: berlin_transport\n    departures:\n      - name: \"S+U Schönhauser Allee\"\n        stop_id: 900110001\n        excluded_lines:\n          - S41\n          - S42\n```\n\nRestart Home Assistant afterwards. This notice does not come back once no stop uses the old form."
     }
   }
 }


### PR DESCRIPTION
This will require migration of yaml configuration, for which an issue will be raised, the old format is still supported.